### PR TITLE
Add uuid to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "engines": {
     "atom": ">=1.19.0 <2.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "uuid": "^3.1.0"
+  },
   "devDependencies": {
     "eslint": "^3.2.2",
     "eslint-config-xo-space": "^0.15.0"


### PR DESCRIPTION
`uuid` is being used but it's not in _package.json_, resulting in the package not being able to load successfully.